### PR TITLE
Fix in Completions API prompt

### DIFF
--- a/synthetic-multi-round-qa/multi-round-qa.py
+++ b/synthetic-multi-round-qa/multi-round-qa.py
@@ -173,7 +173,7 @@ class RequestExecutor:
             else:
                 # Use completions API
                 # Convert messages to a prompt string
-                prompt = "\n".join([f"{msg['role'].upper()}: {msg['content']}" for msg in messages])
+                prompt = "\n".join([f"{msg['role'].upper()}: {msg['content']}" for msg in messages]) + "\nASSISTANT:"
                 
                 response = await self.client.completions.create(
                     model=self.model,
@@ -213,7 +213,7 @@ class RequestExecutor:
                             stream=False,
                         )
                     else:
-                        prompt = "\n".join([f"{msg['role'].upper()}: {msg['content']}" for msg in messages])
+                        prompt = "\n".join([f"{msg['role'].upper()}: {msg['content']}" for msg in messages]) + "\nASSISTANT:"
                         final_response = await self.client.completions.create(
                             model=self.model,
                             prompt=prompt,


### PR DESCRIPTION
When using completions API, for some contents of prompt, some models send response with empty text and one generated token, i.e. do not generate response as expected.
Example of problem:
Request: 
```
curl -X POST http://localhost:8080/v1/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "meta-llama/Llama-3.1-70B-Instruct",
    "prompt": "USER: Hi, here is some system prompt: hi .Here are some other context:  hi.Here is question #1: can?ASSISTANT: Hi",
    "max_tokens": 20,
    "stream": true,
    "stream_options": {
      "include_usage": true
    },
    "temperature": 1
  }'
```

Model: meta-llama/Llama-3.1-70B-Instruct

To case model to continue test generation, "\nASSISTANT:" suffix is to be added to the prompt