### PR TITLE
bug fix: force concurrent user counts via --enforce-strict-concurrent-users 

### DIFF
--- a/synthetic-multi-round-qa/multi-round-qa.py
+++ b/synthetic-multi-round-qa/multi-round-qa.py
@@ -505,8 +505,9 @@ class UserSessionManager:
 
         if self.start_time is None:
             self.start_time = timestamp
-
-        if timestamp - self.last_user_join > self.gap_between_users:
+        
+        # New user session only joins when meets time interval and active user count is less than configured
+        if timestamp - self.last_user_join > self.gap_between_users and len(self.sessions) < self.workload_config.num_users:
             new_session = self._create_user_session()
             if new_session is not None:
                 self.last_user_join = timestamp


### PR DESCRIPTION
Previous #30 PR forced the concurrent users count without the capability to configure or disable it through an input option. This behavior is inconsistent with [multi-round-qa.py](https://github.com/LMCache/LMCache/blob/dev/benchmarks/multi_round_qa/multi-round-qa.py) script under LMCache `benchmark/multi_round_qa`. 

This PR aligns `multi-round-qa.py` in LMBenchmark repo with the upstream version from LMCache’s benchmarking scripts. The related fix has been discussed in https://github.com/LMCache/LMCache/pull/1609. 