### PR TITLE
Improve QPS values argument processing

### DIFF
--- a/sharegpt/run.sh
+++ b/sharegpt/run.sh
@@ -15,7 +15,9 @@ KEY=$3
 
 # If QPS values are provided, use them; otherwise use default
 if [[ $# -gt 3 ]]; then
-    QPS_VALUES=("${@:4}")
+    # Join all remaining arguments and split by spaces
+    all_qps="${*:4}"
+    IFS=' ' read -ra QPS_VALUES <<< "$all_qps"
 else
     QPS_VALUES=(1.34)  # Default QPS value
 fi


### PR DESCRIPTION
This change refactors QPS value handling to correctly support multiple float inputs.

Previously, when multiple QPS values were passed (e.g., "1.34 2.0 3.0"), the script treated them as a single string argument, causing an invalid float value error in sharegpt-qa.py.

The updated logic joins all remaining arguments ("${*:4}") and then splits them using IFS, ensuring that each QPS value is parsed as an individual float.

This makes the benchmark script compatible with multiple QPS inputs and prevents the argparse parsing error.


```
Running ShareGPT benchmark...
usage: sharegpt-qa.py [-h] [--sharegpt-file SHAREGPT_FILE] --base-url BASE_URL
                      --model MODEL --qps QPS [--output OUTPUT]
                      [--log-interval LOG_INTERVAL] [--time TIME] [--verbose]
sharegpt-qa.py: error: argument --qps: invalid float value: '1.34 2.0 3.0'
usage: sharegpt-qa.py [-h] [--sharegpt-file SHAREGPT_FILE] --base-url BASE_URL
                      --model MODEL --qps QPS [--output OUTPUT]
                      [--log-interval LOG_INTERVAL] [--time TIME] [--verbose]
sharegpt-qa.py: error: argument --qps: invalid float value: '1.34 2.0 3.0'
Running short input benchmark...
Warming up with QPS=200...
```
